### PR TITLE
Update cisco-pw.inc.php

### DIFF
--- a/includes/discovery/cisco-pw.inc.php
+++ b/includes/discovery/cisco-pw.inc.php
@@ -20,6 +20,16 @@ if (Config::get('enable_pseudowires') && $device['os_group'] == 'cisco') {
     $pws = snmpwalk_cache_oid($device, 'cpwVcMplsPeerLdpID', $pws, 'CISCO-IETF-PW-MPLS-MIB');
 
     foreach ($pws as $pw_id => $pw) {
+
+		// Added By Oirbsiu
+		// To correct Interface names that use escaped '/' e.g. GigabitEthernet0_4_0_12 
+		// and translate the underscore back to a slash - e.g. GigabitEthernet0/4/0/12
+        $patern = "/((Gigabit)Ethernet)([0-9]+)_+/";
+        if(preg_match($patern, $pw['cpwVcName'])){
+                $pw['cpwVcName'] = preg_replace('/_/', '/', $pw['cpwVcName']);
+        }
+		// END
+
         list($cpw_remote_id) = explode(':', $pw['cpwVcMplsPeerLdpID']);
         $cpw_remote_device   = dbFetchCell('SELECT device_id from ipv4_addresses AS A, ports AS I WHERE A.ipv4_address=? AND A.port_id=I.port_id', array($cpw_remote_id));
         $if_id               = dbFetchCell('SELECT port_id from ports WHERE `ifDescr`=? AND `device_id`=?', array($pw['cpwVcName'], $device['device_id']));
@@ -27,6 +37,7 @@ if (Config::get('enable_pseudowires') && $device['os_group'] == 'cisco') {
             $pseudowire_id = $pws_db[$pw['cpwVcID']];
             echo '.';
         } else {
+            echo "Saving to DB";
             $pseudowire_id = dbInsert(
                 array(
                     'device_id'      => $device['device_id'],


### PR DESCRIPTION
To correct Interface names that use escaped '/' e.g. GigabitEthernet0_4_0_12 
and translate the underscore back to a slash - e.g. GigabitEthernet0/4/0/12

Please give a short description what your pull request is for

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
