### PR TITLE
Update cisco-pw.inc.php

### DIFF
--- a/includes/discovery/cisco-pw.inc.php
+++ b/includes/discovery/cisco-pw.inc.php
@@ -37,7 +37,6 @@ if (Config::get('enable_pseudowires') && $device['os_group'] == 'cisco') {
             $pseudowire_id = $pws_db[$pw['cpwVcID']];
             echo '.';
         } else {
-            echo "Saving to DB";
             $pseudowire_id = dbInsert(
                 array(
                     'device_id'      => $device['device_id'],


### PR DESCRIPTION
The result from 
`SNMP['/usr/bin/snmpbulkwalk' '-v2c' '-c' 'COMMUNITY' '-OQUs' '-m' 'CISCO-IETF-PW-MPLS-MIB' '-M' '/opt/librenms/mibs:/opt/librenms/mibs/cisco' 'udp:HOSTNAME:161' 'cpwVcName']
`
for some devices, may return escaped interface names. 
e.g.
`cpwVcName.2684354565 = GigabitEthernet0_5_0_37`

As part of the discovery process for Pseudowires, this interface name is used in a query to associate the pseudowire_id and the port_id. The query will fail which will result in the pseudowire data being incomplete.

This change is to check if the interface name contains an underscore and replace them with a '/'
the query will now return the correct mapping.

What it does not do - does not update already present pseudowire entries 



#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)
- [ ] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
